### PR TITLE
Add comma separators to the Discord Webhook

### DIFF
--- a/Utils/Discord/DSWebHook.cs
+++ b/Utils/Discord/DSWebHook.cs
@@ -88,7 +88,7 @@ namespace ToNSaveManager.Utils.Discord
                         if (entry.RTerrors != null && entry.RTerrors.Length > 0)
                         {
                             if (EmbedData.Description.Length > 0) EmbedData.Description += "\n";
-                            EmbedData.Description += "**Terrors in Round**: `" + string.Join("` `", entry.RTerrors) + "`";
+                            EmbedData.Description += "**Terrors in Round**: `" + string.Join("`, `", entry.RTerrors) + "`";
                         }
 
                         if (entry.PlayerCount > 0)


### PR DESCRIPTION
It's not much since I'm not really familiar with .NET C#, but here's a really simple change to have comma separators on the Discord Webhook
![Screenshot 2024-07-14 203018](https://github.com/user-attachments/assets/f31647e2-b816-43a0-b464-2b69b24add81)
